### PR TITLE
Throw installation exceptions

### DIFF
--- a/src/NLog/Config/InstallationContext.cs
+++ b/src/NLog/Config/InstallationContext.cs
@@ -77,6 +77,7 @@ namespace NLog.Config
             this.LogOutput = logOutput;
             this.Parameters = new Dictionary<string, string>();
             this.LogLevel = LogLevel.Info;
+            this.ThrowExceptions = false;
         }
 
         /// <summary>
@@ -98,6 +99,12 @@ namespace NLog.Config
         /// Gets or sets the log output.
         /// </summary>
         public TextWriter LogOutput { get; set; }
+
+        /// <summary>
+        /// Whether installation exceptions should be rethrown. By default,
+        /// installation exceptions are not rethrown.
+        /// </summary>
+        public bool ThrowExceptions { get; set; }
 
         /// <summary>
         /// Logs the specified trace message.

--- a/src/NLog/Config/InstallationContext.cs
+++ b/src/NLog/Config/InstallationContext.cs
@@ -91,6 +91,12 @@ namespace NLog.Config
         public bool IgnoreFailures { get; set; }
 
         /// <summary>
+        /// Whether installation exceptions should be rethrown. If IgnoreFailures is set to true,
+        /// this property has no effect (there are no exceptions to rethrow).
+        /// </summary>
+        public bool ThrowExceptions { get; set; }
+
+        /// <summary>
         /// Gets the installation parameters.
         /// </summary>
         public IDictionary<string, string> Parameters { get; private set; }
@@ -99,12 +105,6 @@ namespace NLog.Config
         /// Gets or sets the log output.
         /// </summary>
         public TextWriter LogOutput { get; set; }
-
-        /// <summary>
-        /// Whether installation exceptions should be rethrown. By default,
-        /// installation exceptions are not rethrown.
-        /// </summary>
-        public bool ThrowExceptions { get; set; }
 
         /// <summary>
         /// Logs the specified trace message.

--- a/src/NLog/Config/LoggingConfiguration.cs
+++ b/src/NLog/Config/LoggingConfiguration.cs
@@ -372,7 +372,7 @@ namespace NLog.Config
                 catch (Exception exception)
                 {
                     InternalLogger.Error(exception, "Install of '{0}' failed.", installable);
-                    if (exception.MustBeRethrownImmediately())
+                    if (exception.MustBeRethrownImmediately() || installationContext.ThrowExceptions)
                     {
                         throw;
                     }

--- a/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
+++ b/tests/NLog.UnitTests/Targets/DatabaseTargetTests.cs
@@ -837,7 +837,7 @@ Dispose()
             dt.Initialize(null);
             Assert.Equal(typeof(System.Data.Odbc.OdbcConnection), dt.ConnectionType);
         }
-
+        
         [Fact]
         public void SQLite_InstallAndLogMessageProgrammatically()
         {
@@ -909,6 +909,15 @@ Dispose()
             }
         }
 
+        private string GetSQLiteDbProvider()
+        {
+#if MONO
+            return "Mono.Data.Sqlite.SqliteConnection, Mono.Data.Sqlite";
+#else
+            return "System.Data.SQLite.SQLiteConnection, System.Data.SQLite";
+#endif
+        }
+
         [Fact]
         public void SQLite_InstallAndLogMessage()
         {
@@ -923,12 +932,8 @@ Dispose()
                 sqlLite.CreateDatabase();
 
                 var connectionString = sqlLite.GetConnectionString();
-                string dbProvider = "";
-#if MONO 
-                dbProvider = "Mono.Data.Sqlite.SqliteConnection, Mono.Data.Sqlite";
-#else
-                dbProvider = "System.Data.SQLite.SQLiteConnection, System.Data.SQLite";
-#endif
+                string dbProvider = GetSQLiteDbProvider();
+
                 // Create log with xml config
                 LogManager.Configuration = CreateConfigurationFromString(@"
             <nlog xmlns='http://www.nlog-project.org/schemas/NLog.xsd'
@@ -972,6 +977,63 @@ Dispose()
             {
                 sqlLite.TryDropDatabase();
             }
+        }
+
+        private void SetupInvalidSQLiteDatabase(string databaseName)
+        {
+            var nlogXmlConfig = @"
+            <nlog xmlns='http://www.nlog-project.org/schemas/NLog.xsd'
+                  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' throwExceptions='true'>
+                <targets>
+                    <target name='database' xsi:type='Database' dbProvider='{0}' connectionstring='{1}' 
+                        commandText='insert into NLogSqlLiteTest (Message) values (@message);'>
+                        <parameter name='@message' layout='${{message}}' />
+                        <install-command ignoreFailures='false'
+                                         text='DROP TABLE NonExistingTable (
+                            Id int PRIMARY KEY,
+                            Message varchar(100) NULL
+                        );' />
+                    </target>
+                </targets>
+                <rules>
+                    <logger name='*' writeTo='database' />
+                </rules>
+            </nlog>";
+
+            // Use an in memory SQLite database
+            // See https://www.sqlite.org/inmemorydb.html
+            var connectionString = String.Format("FullUri=file::{0}:;Version=3", databaseName);
+
+            LogManager.Configuration = CreateConfigurationFromString(
+                String.Format(nlogXmlConfig, GetSQLiteDbProvider(), connectionString)
+            );
+        }
+
+        [Fact]
+        public void NotRethrowingInstallExceptions()
+        {
+            SetupInvalidSQLiteDatabase("rethrowing_install_exceptions");
+
+            // Default InstallationContext should not rethrow exceptions
+            InstallationContext context = new InstallationContext();
+            Assert.False(context.ThrowExceptions);
+            
+            Assert.DoesNotThrow(() => LogManager.Configuration.Install(context));
+        }
+        
+        [Fact]
+        public void RethrowingInstallExceptions()
+        {
+            SetupInvalidSQLiteDatabase("rethrowing_install_exceptions");
+
+            InstallationContext context = new InstallationContext()
+            {
+                ThrowExceptions = true
+            };
+
+            Assert.True(context.ThrowExceptions);  // Sanity check
+            
+            Assert.Throws<SQLiteException>(() => LogManager.Configuration.Install(context));
         }
 
         [Fact]


### PR DESCRIPTION
Currently, exceptions thrown during the installation of a target (e.g. database target) are caught by the [`LoggingConfiguration`](https://github.com/rbarillec/NLog/blob/master/src/NLog/Config/LoggingConfiguration.cs#L372) and logged internally. It can be useful for client code to know that the target installation has failed, so that they can for instance let a user know that logging has failed to start.

This change adds a `bool InstallationContext.ThrowExceptions` property which allows installation exceptions to be rethrown by the `LoggingConfiguration`. Note that for the exceptions to be thrown in the first place, `IgnoreFailures` needs to be set to `false` on both the `CommandInfo` and the `InstallationContext` (at least for the [`DatabaseTarget`](https://github.com/rbarillec/NLog/blob/master/src/NLog/Targets/DatabaseTarget.cs#L694)). If `IgnoreFailures` is set to true on either, then the `ThrowExceptions` property will have no effect.